### PR TITLE
refactor: 라우트에서 레이아웃 주입하도록 구조 리팩토링

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,8 @@
 <script setup>
-import LayoutDefault from "@/components/layout/LayoutDefault.vue";
 </script>
 
 <template>
-  <LayoutDefault />
+  <RouterView/>
 </template>
 
 <style>

--- a/src/components/layout/sidebar/SidebarSection.vue
+++ b/src/components/layout/sidebar/SidebarSection.vue
@@ -15,10 +15,11 @@ import { ref, watch } from 'vue'
 import SidebarGroup from './SidebarGroup.vue'
 
 const props = defineProps({
-  groups: Array
+  groups: Array,
+  default: () => []
 })
 
-const openGroups = ref(props.groups.map(group => group.title))
+const openGroups = ref(props.groups?.map(group => group.title) || [])
 
 const toggleGroup = (title) => {
   if (openGroups.value.includes(title)) {
@@ -31,7 +32,7 @@ const toggleGroup = (title) => {
 watch(
     () => props.groups,
     (newGroups) => {
-      openGroups.value = newGroups.map(g => g.title)
+      openGroups.value = newGroups?.map(g => g.title) || []
     },
     { immediate: true }
 )

--- a/src/constants/sidebarMap.js
+++ b/src/constants/sidebarMap.js
@@ -56,7 +56,7 @@ export const sidebarMap = {
             icon: 'fas fa-warehouse',
             items: [
                 { name: "창고 조회", route: "/warehouse/list", roles: ["GENERAL_MANAGER", "SENIOR_MANAGER", "WAREHOUSE_MANAGER"] },
-                { name: "보유 재고 조회", route: "/warehouse/inventory", roles: ["GENERAL_MANAGER", "SENIOR_MANAGER", "WAREHOUSE_MANAGER"] },
+                { name: "보유 재고 조회", route: "/warehouse/inventory/list", roles: ["GENERAL_MANAGER", "SENIOR_MANAGER", "WAREHOUSE_MANAGER"] },
                 { name: "보유 재고 등록", route: "/warehouse/inventory/register", roles: ["WAREHOUSE_MANAGER"] }
             ]
         }

--- a/src/features/delivery/router.js
+++ b/src/features/delivery/router.js
@@ -4,7 +4,7 @@ import DeliveryDummyView from "@/features/delivery/views/DeliveryDummyView.vue";
 export const deliveryRoutes = [
     {
         path: '/delivery/list',
-        name: 'DeliveryDummyView',
+        name: 'DeliveryDummy1View',
         component: DeliveryDummyView
     },
 ];

--- a/src/features/delivery/views/DeliveryDummyView.vue
+++ b/src/features/delivery/views/DeliveryDummyView.vue
@@ -3,7 +3,7 @@
 </script>
 
 <template>
-
+  DeliveryDummyView
 </template>
 
 <style scoped>

--- a/src/features/disposal/router.js
+++ b/src/features/disposal/router.js
@@ -4,22 +4,22 @@ import DisposalDummyView from "@/features/disposal/views/DisposalDummyView.vue";
 export const disposalRoutes = [
     {
         path: '/disposal/franchise/list',
-        name: 'DisposalDummyView',
+        name: 'DisposalDummy1View',
         component: DisposalDummyView
     },
     {
         path: '/disposal/franchise/register',
-        name: 'DisposalDummyView',
+        name: 'DisposalDummy2View',
         component: DisposalDummyView
     },
     {
         path: '/disposal/warehouse/list',
-        name: 'DisposalDummyView',
+        name: 'DisposalDummy3View',
         component: DisposalDummyView
     },
     {
         path: '/disposal/warehouse/register',
-        name: 'DisposalDummyView',
+        name: 'DisposalDummy4View',
         component: DisposalDummyView
     },
 ];

--- a/src/features/disposal/views/DisposalDummyView.vue
+++ b/src/features/disposal/views/DisposalDummyView.vue
@@ -3,7 +3,7 @@
 </script>
 
 <template>
-
+  DisposalDummyView
 </template>
 
 <style scoped>

--- a/src/features/franchise/router.js
+++ b/src/features/franchise/router.js
@@ -4,7 +4,7 @@ import FranchiseDummyView from "@/features/franchise/views/FranchiseDummyView.vu
 export const franchiseRoutes = [
     {
         path: '/franchise/list',
-        name: 'FranchiseDummyView',
+        name: 'FranchiseDummy1View',
         component: FranchiseDummyView
     },
 ];

--- a/src/features/member/router.js
+++ b/src/features/member/router.js
@@ -4,27 +4,27 @@ import MemberDummyView from "@/features/member/views/MemberDummyView.vue";
 export const memberRoutes = [
     {
         path: '/members/list',
-        name: 'MemberDummyView',
+        name: 'MemberDummy1View',
         component: MemberDummyView
     },
     {
         path: '/members/logs',
-        name: 'MemberDummyView',
+        name: 'MemberDummy2View',
         component: MemberDummyView
     },
     {
         path: '/members/register',
-        name: 'MemberDummyView',
+        name: 'MemberDummy3View',
         component: MemberDummyView
     },
     {
         path: '/mypage/password',
-        name: 'MemberDummyView',
+        name: 'MemberDummy4View',
         component: MemberDummyView
     },
     {
         path: '/mypage/info',
-        name: 'MemberDummyView',
+        name: 'MemberDummy5View',
         component: MemberDummyView
     },
 ];

--- a/src/features/member/views/MemberDummyView.vue
+++ b/src/features/member/views/MemberDummyView.vue
@@ -3,7 +3,7 @@
 </script>
 
 <template>
-
+  MemberDummyView
 </template>
 
 <style scoped>

--- a/src/features/order/router.js
+++ b/src/features/order/router.js
@@ -3,12 +3,12 @@ import OrderDummyView from "@/features/order/views/OrderDummyView.vue";
 export const orderRoutes = [
     {
         path: '/order/list',
-        name: 'OrderDummyView',
+        name: 'OrderDummy1View',
         component: OrderDummyView
     },
     {
         path: '/order/register',
-        name: 'OrderDummyView',
+        name: 'OrderDummy2View',
         component: OrderDummyView
     },
 ];

--- a/src/features/order/views/OrderDummyView.vue
+++ b/src/features/order/views/OrderDummyView.vue
@@ -3,7 +3,7 @@
 </script>
 
 <template>
-
+  OrderDummyView
 </template>
 
 <style scoped>

--- a/src/features/product/router.js
+++ b/src/features/product/router.js
@@ -3,32 +3,32 @@ import ProductDummyView from "@/features/product/views/ProductDummyView.vue";
 export const productRoutes = [
     {
         path: '/category/list',
-        name: 'ProductDummyView',
+        name: 'ProductDummy1View',
         component: ProductDummyView
     },
     {
         path: '/category/register',
-        name: 'ProductDummyView',
+        name: 'ProductDummy2View',
         component: ProductDummyView
     },
     {
         path: '/product/list',
-        name: 'ProductDummyView',
+        name: 'ProductDummy3View',
         component: ProductDummyView
     },
     {
         path: '/product/register',
-        name: 'ProductDummyView',
+        name: 'ProductDummy4View',
         component: ProductDummyView
     },
     {
         path: '/contract/list',
-        name: 'ProductDummyView',
+        name: 'ProductDummy5View',
         component: ProductDummyView
     },
     {
         path: '/contract/register',
-        name: 'ProductDummyView',
+        name: 'ProductDummy6View',
         component: ProductDummyView
     },
 ];

--- a/src/features/product/views/ProductDummyView.vue
+++ b/src/features/product/views/ProductDummyView.vue
@@ -3,7 +3,7 @@
 </script>
 
 <template>
-
+  ProductDummyView
 </template>
 
 <style scoped>

--- a/src/features/purchase/router.js
+++ b/src/features/purchase/router.js
@@ -3,12 +3,12 @@ import PurchaseDummyView from "@/features/purchase/views/PurchaseDummyView.vue";
 export const purchaseRoutes = [
     {
         path: '/purchase/list',
-        name: 'PurchaseDummyView',
+        name: 'PurchaseDummy1View',
         component: PurchaseDummyView
     },
     {
         path: '/stockin/list',
-        name: 'PurchaseDummyView',
+        name: 'PurchaseDummy2View',
         component: PurchaseDummyView
     },
 ];

--- a/src/features/purchase/views/PurchaseDummyView.vue
+++ b/src/features/purchase/views/PurchaseDummyView.vue
@@ -3,7 +3,7 @@
 </script>
 
 <template>
-
+  PurchaseDummyView
 </template>
 
 <style scoped>

--- a/src/features/requisition/router.js
+++ b/src/features/requisition/router.js
@@ -3,12 +3,12 @@ import RequisitionDummyView from "@/features/requisition/views/RequisitionDummyV
 export const requisitionRoutes = [
     {
         path: '/requisition/list',
-        name: 'RequisitionDummyView',
+        name: 'RequisitionDummy1View',
         component: RequisitionDummyView
     },
     {
         path: '/requisition/register',
-        name: 'RequisitionDummyView',
+        name: 'RequisitionDummy2View',
         component: RequisitionDummyView
     },
 ];

--- a/src/features/requisition/views/RequisitionDummyView.vue
+++ b/src/features/requisition/views/RequisitionDummyView.vue
@@ -3,7 +3,7 @@
 </script>
 
 <template>
-
+  RequisitionDummyView
 </template>
 
 <style scoped>

--- a/src/features/statistics/router.js
+++ b/src/features/statistics/router.js
@@ -1,35 +1,35 @@
-import DashboardDummyView from "@/features/statistics/views/DashboardDummyView.vue";
+import DashboardDummyView from '../statistics/views/DashboardDummyView.vue'
 
 /* 사용자가 보는 routes와 view를 연결 */
 export const dashboardRoutes = [
     {
         path: '/dashboard/prediction',
-        name: 'DashboardDummyView',
+        name: 'DashboardDummy1View',
         component: DashboardDummyView
     },
     {
         path: '/dashboard/accuracy',
-        name: 'DashboardDummyView',
+        name: 'DashboardDummy2View',
         component: DashboardDummyView
     },
     {
         path: '/dashboard/sales',
-        name: 'DashboardDummyView',
+        name: 'DashboardDummy3View',
         component: DashboardDummyView
     },
     {
         path: '/dashboard/inventory-turn',
-        name: 'DashboardDummyView',
+        name: 'DashboardDummy4View',
         component: DashboardDummyView
     },
     {
         path: '/dashboard/purchase-stats',
-        name: 'DashboardDummyView',
+        name: 'DashboardDummy5View',
         component: DashboardDummyView
     },
     {
         path: '/dashboard/dispose-stats',
-        name: 'DashboardDummyView',
+        name: 'DashboardDummy6View',
         component: DashboardDummyView
     },
 ];

--- a/src/features/statistics/views/DashboardDummyView.vue
+++ b/src/features/statistics/views/DashboardDummyView.vue
@@ -3,7 +3,7 @@
 </script>
 
 <template>
-
+  DashboardDummyView
 </template>
 
 <style scoped>

--- a/src/features/takeback/router.js
+++ b/src/features/takeback/router.js
@@ -3,7 +3,7 @@ import TakeBackDummyView from "@/features/takeback/views/TakeBackDummyView.vue";
 export const takebackRoutes = [
     {
         path: '/takeback/list',
-        name: 'TakeBackDummyView',
+        name: 'TakeBackDummy1View',
         component: TakeBackDummyView
     },
 ];

--- a/src/features/takeback/views/TakeBackDummyView.vue
+++ b/src/features/takeback/views/TakeBackDummyView.vue
@@ -3,7 +3,7 @@
 </script>
 
 <template>
-
+  TakeBackDummyView
 </template>
 
 <style scoped>

--- a/src/features/vendor/api.js
+++ b/src/features/vendor/api.js
@@ -1,0 +1,10 @@
+import api from '@/api/axios.js'
+
+/* 컨텍스트 별로 각각 백엔드와 연결되는 api*/
+export function firstDummyAPI(memberId) {
+    return api.get(`/firstDummy/${memberId}`);
+}
+
+export function secondDummyAPI(memberId) {
+    return api.get(`/secondDummy/${memberId}`);
+}

--- a/src/features/vendor/components/component.vue
+++ b/src/features/vendor/components/component.vue
@@ -3,7 +3,7 @@
 </script>
 
 <template>
-  FranchiseDummyView
+
 </template>
 
 <style scoped>

--- a/src/features/vendor/router.js
+++ b/src/features/vendor/router.js
@@ -1,0 +1,9 @@
+import VendorDummyView from "@/features/vendor/views/VendorDummyView.vue";
+
+export const vendorRoutes = [
+    {
+        path: '/vendor/list',
+        name: 'VendorDummy1View',
+        component: VendorDummyView
+    },
+];

--- a/src/features/vendor/views/VendorDummyView.vue
+++ b/src/features/vendor/views/VendorDummyView.vue
@@ -3,7 +3,7 @@
 </script>
 
 <template>
-  FranchiseDummyView
+  VendorDummyView
 </template>
 
 <style scoped>

--- a/src/features/warehouse/router.js
+++ b/src/features/warehouse/router.js
@@ -3,17 +3,17 @@ import WarehouseDummyView from "@/features/warehouse/views/WarehouseDummyView.vu
 export const warehouseRoutes = [
     {
         path: '/warehouse/list',
-        name: 'WarehouseDummyView',
+        name: 'WarehouseDummy1View',
         component: WarehouseDummyView
     },
     {
-        path: '/warehouse/inventory',
-        name: 'WarehouseDummyView',
+        path: '/warehouse/inventory/list',
+        name: 'WarehouseDummy2View',
         component: WarehouseDummyView
     },
     {
         path: '/warehouse/inventory/register',
-        name: 'WarehouseDummyView',
+        name: 'WarehouseDummy3View',
         component: WarehouseDummyView
     },
 ];

--- a/src/features/warehouse/views/WarehouseDummyView.vue
+++ b/src/features/warehouse/views/WarehouseDummyView.vue
@@ -3,7 +3,7 @@
 </script>
 
 <template>
-
+  WarehouseDummyView
 </template>
 
 <style scoped>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,17 +2,18 @@ import { createRouter, createWebHistory } from 'vue-router'
 
 import LayoutDefault from '/src/components/layout/LayoutDefault.vue'
 
-import { memberRoutes } from "@/features/member/router.js";
-import { productRoutes } from "@/features/product/router.js";
-import { franchiseRoutes } from "@/features/franchise/router.js";
-import { warehouseRoutes } from "@/features/warehouse/router.js";
-import { orderRoutes } from "@/features/order/router.js";
 import { deliveryRoutes } from "@/features/delivery/router.js";
 import { disposalRoutes } from "@/features/disposal/router.js";
+import { franchiseRoutes } from "@/features/franchise/router.js";
+import { memberRoutes } from "@/features/member/router.js";
+import { orderRoutes } from "@/features/order/router.js";
+import { productRoutes } from "@/features/product/router.js";
 import { purchaseRoutes } from "@/features/purchase/router.js";
 import { requisitionRoutes } from "@/features/requisition/router.js";
 import { dashboardRoutes } from "@/features/statistics/router.js";
 import { takebackRoutes } from "@/features/takeback/router.js";
+import { vendorRoutes } from "@/features/vendor/router.js";
+import { warehouseRoutes } from "@/features/warehouse/router.js";
 
 const router = createRouter({
   history: createWebHistory(),
@@ -35,6 +36,7 @@ const router = createRouter({
           ...requisitionRoutes,
           ...dashboardRoutes,
           ...takebackRoutes,
+          ...vendorRoutes,
           ...warehouseRoutes
       ]
     }


### PR DESCRIPTION
Closes #3

## 🔥 작업 내용  
- 누락된 컨텍스트에 대한 더미 구조 구현
- 각 컨텍스트 별 라우트에 고유 name 부여
- App.vue에서 LayoutDefault가 아닌 RouterView를 호출하도록 구조 변경
- 초기 렌더링 상태를 위한 사이드바 선택 상태 분기 처리 

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인

## ✨ 관련 이슈
- #3
