### PR TITLE
refactor: 사이드바의 활성화 상태 구조 개선

### DIFF
--- a/src/components/layout/LayoutDefault.vue
+++ b/src/components/layout/LayoutDefault.vue
@@ -110,6 +110,6 @@ const handleSelectMenu = (menu) => {
   flex: 1;
   padding: 1.5rem 2rem;
   overflow-y: auto;
-  background-color: #fff;
+  background-color: #f4f6f9;
 }
 </style>

--- a/src/components/layout/sidebar/SidebarItemList.vue
+++ b/src/components/layout/sidebar/SidebarItemList.vue
@@ -16,6 +16,7 @@
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 // import { useUserStore } from '@/stores/user'
+import { routeAliasMap } from '@/constants/activeSidebarMap.js'
 
 const props = defineProps({
   items: Array
@@ -32,7 +33,16 @@ const route = useRoute()
 
 const isActive = (itemRoute) => {
   if (!itemRoute) return false
-  return route.path.startsWith(itemRoute)
+
+  const currentPath = route.path
+
+  // alias 매핑이 있다면 해당 기준으로 대체
+  const aliasTarget = Object.entries(routeAliasMap).find(([alias]) =>
+      currentPath.startsWith(alias)
+  )
+  const normalizedPath = aliasTarget ? aliasTarget[1] : currentPath
+
+  return normalizedPath.startsWith(itemRoute)
 }
 </script>
 

--- a/src/constants/activeSidebarMap.js
+++ b/src/constants/activeSidebarMap.js
@@ -1,0 +1,10 @@
+export const routeAliasMap = {
+    // '사이드 바에 없는 라우트 주소' : '활성화 시킬 사이드바 아이템'
+    '/order/detail': '/order/list',
+    '/order/edit': '/order/list',
+    '/takeback/detail': '/takeback/list',
+    '/delivery/detail': '/delivery/list',
+    '/product/detail': '/product/list',
+    '/members/detail': '/members/list',
+    '/mypage/info/edit': '/mypage/info',
+}

--- a/src/features/order/router.js
+++ b/src/features/order/router.js
@@ -11,4 +11,9 @@ export const orderRoutes = [
         name: 'OrderDummy2View',
         component: OrderDummyView
     },
+    {
+        path: '/order/detail',
+        name: 'OrderDummy3View',
+        component: OrderDummyView
+    },
 ];


### PR DESCRIPTION
Closes #6

## 🔥 작업 내용  
- 사이드바에 없는 별개의 라우트에서도 사이드바 아이템 활성화 가능하도록 구조 개선

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인

## ✨ 관련 이슈
- #6
