### PR TITLE
feat: 회원 상세 페이지 기능 구현

### DIFF
--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -49,7 +49,9 @@ api.interceptors.response.use(
                     return api(originalRequest);
                 } catch (refreshError) {
                     authStore.clearAuth();
-                    await router.push("/login");
+                    router.push('/login').then(() => {
+                        window.location.reload();
+                    });
                     return Promise.reject(refreshError);
                 }
             }

--- a/src/components/common/filters/FilterDateRange.vue
+++ b/src/components/common/filters/FilterDateRange.vue
@@ -15,6 +15,7 @@ import { ref, onMounted, watch } from 'vue'
 import flatpickr from 'flatpickr'
 import 'flatpickr/dist/flatpickr.min.css'
 import '@/assets/css/flatpickr-custom.css'
+import { Korean } from 'flatpickr/dist/l10n/ko.js'
 
 const props = defineProps({
     label: String,
@@ -38,7 +39,7 @@ onMounted(() => {
         mode: 'range',
         dateFormat: 'Y-m-d',
         defaultDate: [props.modelValue?.start, props.modelValue?.end],
-        locale: 'ko',  // 한국어 로케일 설정
+        locale: Korean,  // 한국어 로케일 설정
         onChange: (selectedDates) => {
             // 날짜 범위 선택 시
             if (selectedDates.length === 1) {

--- a/src/features/auth/useAuthStore.js
+++ b/src/features/auth/useAuthStore.js
@@ -1,12 +1,13 @@
 import { defineStore } from "pinia";
 import router from "@/router";
-import { refreshApi as refreshApi } from "@/features/auth/api.js";
+import { refreshApi } from "@/features/auth/api.js";
 
 export const useAuthStore = defineStore("auth", {
     state: () => ({
         accessToken: "",
         email: "",
         saveId: false,
+        authority: ""
     }),
     actions: {
         setAccessToken(token) {
@@ -18,17 +19,22 @@ export const useAuthStore = defineStore("auth", {
         setSaveId(save) {
             this.saveId = save;
         },
+        setAuthority(authority) {
+            this.authority = authority;
+        },
         clearAuth() {
             if (!this.saveId) {
                 this.email = "";
             }
             this.accessToken = "";
+            this.authority = "";
+            localStorage.removeItem('auth');
         },
         async refreshToken() {
             try {
-                const res = await refreshApi(); // 쿠키 기반 요청
-                this.setAccessToken(res.data.accessToken); // 스토어 갱신
-                return res.data.accessToken; // Axios 재시도에서 사용
+                const res = await refreshApi();
+                this.setAccessToken(res.data.accessToken);
+                return res.data.accessToken;
             } catch (error) {
                 console.error("refreshToken 실패:", error);
                 this.clearAuth();

--- a/src/features/auth/views/login/LoginView.vue
+++ b/src/features/auth/views/login/LoginView.vue
@@ -11,7 +11,8 @@
             </div>
             <div class="input-group">
                 <i class="fas fa-lock input-icon"></i>
-                <i :class="showPassword ? 'fas fa-eye toggle-password' : 'fas fa-eye-slash toggle-password'" @click="togglePassword"></i>
+                <i :class="showPassword ? 'fas fa-eye toggle-password' : 'fas fa-eye-slash toggle-password'"
+                   @click="togglePassword"></i>
                 <input :type="showPassword ? 'text' : 'password'" v-model="password" placeholder="비밀번호" required/>
             </div>
             <div v-if="errorMessage" class="error-message">{{ errorMessage }}</div>
@@ -19,17 +20,18 @@
                 <input type="checkbox" id="saveId" v-model="saveId" @change="handleSaveIdChange"/>
                 <label for="saveId">아이디 저장</label>
             </div>
-            <StatusButton type="primary" :disabled="isSubmitting" @click="handleLogin" id="error-btn">로그인</StatusButton>
+            <StatusButton type="primary" :disabled="isSubmitting" id="error-btn">로그인</StatusButton>
         </form>
     </div>
 </template>
 
 <script setup>
-import { ref, watch, onMounted } from 'vue';
-import { useRouter } from 'vue-router';
+import {ref, onMounted} from 'vue';
+import {useRouter} from 'vue-router';
 import logo from '@/assets/images/chainware-logo.png';
-import { useAuthStore } from '@/features/auth/useAuthStore';
-import { loginApi } from '@/features/auth/api';
+import {useAuthStore} from '@/features/auth/useAuthStore';
+import {loginApi} from '@/features/auth/api';
+import {parseJwt} from '@/utils/jwt';
 import StatusButton from "@/components/common/StatusButton.vue";
 
 const router = useRouter();
@@ -59,7 +61,7 @@ function handleSaveIdChange() {
         if (trimmedEmail !== '' && isValidEmail(trimmedEmail)) {
             authStore.setEmail(trimmedEmail);
             authStore.setSaveId(true);
-            errorMessage.value = ''; // 에러 초기화
+            errorMessage.value = '';
         } else {
             errorMessage.value = '올바른 이메일을 입력해주세요.';
             saveId.value = false;
@@ -67,7 +69,7 @@ function handleSaveIdChange() {
     } else {
         authStore.setEmail('');
         authStore.setSaveId(false);
-        errorMessage.value = ''; // 에러 초기화
+        errorMessage.value = '';
     }
 }
 
@@ -82,8 +84,13 @@ async function handleLogin() {
         const res = await loginApi(email.value, password.value);
 
         if (res.success && res.data) {
-            const { accessToken } = res.data;
+            const {accessToken} = res.data;
             authStore.setAccessToken(accessToken);
+
+            // JWT 디코드 후 authority 추출
+            const decoded = parseJwt(accessToken);
+            // console.log('Decoded JWT:', decoded); // 필요 시 확인 후 제거
+            authStore.setAuthority(decoded.authority);
 
             if (saveId.value) {
                 authStore.setEmail(email.value);
@@ -250,7 +257,6 @@ input[type="password"]:focus {
     transform: translate(-50%, -50%);
 }
 
-/* ID 적용한 스타일 */
 #error-btn {
     width: 100%;
     padding: 16px;

--- a/src/features/member/api.js
+++ b/src/features/member/api.js
@@ -1,16 +1,13 @@
 import api from '@/api/axios.js'
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
-
-/* 컨텍스트 별로 각각 백엔드와 연결되는 api*/
-export function firstDummyAPI(memberId) {
-    return api.get(`/firstDummy/${memberId}`);
-}
-
-export function secondDummyAPI(memberId) {
-    return api.get(`/secondDummy/${memberId}`);
-}
-
 export const getMembers = (params) => {
-    return api.get(`${API_BASE_URL}/members`, { params })
+    return api.get("/members", {params})
+}
+
+export const getMemberDetail = (memberId) => {
+    return api.get(`/members/${memberId}`)
+}
+
+export const getMemberLoginHistory = (memberId, params) => {
+    return api.get(`/members/${memberId}/login-history`, {params})
 }

--- a/src/features/member/master/components/DetailRow.vue
+++ b/src/features/member/master/components/DetailRow.vue
@@ -1,0 +1,29 @@
+<template>
+    <div class="detail-row">
+        <span class="label">{{ label }}</span>
+        <span class="value">{{ value }}</span>
+    </div>
+</template>
+
+<script setup>
+defineProps({
+    label: String,
+    value: [String, Number]
+})
+</script>
+
+<style scoped>
+.detail-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--color-gray-100);
+}
+.label {
+    font-weight: 500;
+    color: var(--color-gray-600);
+}
+.value {
+    color: var(--color-gray-900);
+}
+</style>

--- a/src/features/member/master/components/MemberDetailBasic.vue
+++ b/src/features/member/master/components/MemberDetailBasic.vue
@@ -1,0 +1,228 @@
+<template>
+    <div class="card">
+        <div class="section-header">
+            <div class="title-wrapper">
+                <div class="indicator"></div>
+                <h2 class="title">회원 정보</h2>
+            </div>
+            <RouterLink :to="`/member/${props.member.memberId}/edit`" class="action-button">
+                수정
+            </RouterLink>
+        </div>
+        <p class="description">회원 상세 내용을 확인할 수 있습니다.</p>
+
+        <div class="info-grid">
+            <div v-for="item in rows" :key="item.label" class="info-item">
+                <div class="label">{{ item.label }}</div>
+                <div class="value">
+                    <template v-if="item.type === 'badge'">
+                        <span :class="['badge', item.badgeClass]">{{ item.value }}</span>
+                    </template>
+                    <template v-else>
+                        {{ item.value || '-' }}
+                    </template>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+const props = defineProps({
+    member: {type: Object, required: true}
+})
+
+function formatDateTime(dateTime) {
+    if (!dateTime) return '-'
+    const date = new Date(dateTime)
+    return date.toLocaleString('ko-KR', {timeZone: 'Asia/Seoul'})
+}
+
+function formatPhoneNumber(phoneNumber) {
+    if (!phoneNumber) return '-'
+    const cleaned = phoneNumber.replace(/\D/g, '')
+    if (cleaned.length === 10) {
+        return cleaned.replace(/(\d{3})(\d{3})(\d{4})/, '$1-$2-$3')
+    }
+    if (cleaned.length === 11) {
+        return cleaned.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3')
+    }
+    return phoneNumber
+}
+
+function authorityBadgeClass(label) {
+    switch (label) {
+        case '마스터':
+            return 'badge-master'
+        case '일반 관리자':
+            return 'badge-general'
+        case '책임 관리자':
+            return 'badge-senior'
+        case '창고 관리자':
+            return 'badge-warehouse'
+        case '가맹점 담당자':
+            return 'badge-franchise'
+        case '거래처 담당자':
+            return 'badge-vendor'
+        default:
+            return 'badge-default'
+    }
+}
+
+const rows = [
+    {label: '회원 ID', value: props.member.memberId},
+    {label: '이메일', value: props.member.email},
+    {label: '이름', value: props.member.name},
+    {
+        label: '권한',
+        value: props.member.authorityLabelKr,
+        type: 'badge',
+        badgeClass: authorityBadgeClass(props.member.authorityLabelKr)
+    },
+    {label: '전화번호', value: formatPhoneNumber(props.member.phoneNumber)},
+    {label: '생년월일', value: props.member.birthDate},
+    {label: '직책', value: props.member.position},
+    {label: '가입일', value: formatDateTime(props.member.joinAt)},
+    {label: '수정일', value: formatDateTime(props.member.modifiedAt)},
+    {
+        label: '탈퇴 여부',
+        value: props.member.isDeleted ? '탈퇴' : '활동 중',
+        type: 'badge',
+        badgeClass: props.member.isDeleted ? 'badge-inactive' : 'badge-active'
+    },
+]
+</script>
+
+<style scoped>
+.card {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    max-width: 1500px;
+    margin: 0 auto;
+    width: 100%;
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.title-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.title {
+    font-size: var(--font-page-title-large);
+    font-weight: bold;
+    color: var(--color-gray-900);
+    margin-bottom: 4px;
+    border-left: 4px solid var(--color-primary);
+    padding-left: 10px;
+}
+
+.description {
+    font-size: 0.95rem;
+    color: #6c757d;
+    margin-bottom: 16px;
+}
+
+.action-button {
+    padding: 6px 14px;
+    background-color: var(--color-primary, #2F80ED);
+    color: #fff;
+    border-radius: 6px;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 0.9rem;
+    transition: background-color 0.2s ease;
+}
+
+.action-button:hover {
+    background-color: var(--color-primary-dark, #1c60b3);
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+@media (max-width: 768px) {
+    .info-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.info-item {
+    background: #f9fafb;
+    border-radius: 8px;
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+}
+
+.label {
+    font-size: 0.85rem;
+    color: #6c757d;
+    margin-bottom: 4px;
+}
+
+.value {
+    font-weight: 600;
+    color: #212529;
+    word-break: break-all;
+}
+
+.badge {
+    padding: 4px 10px;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    color: #fff;
+    display: inline-block;
+    text-align: center;
+}
+
+/* 탈퇴 여부 배지 */
+.badge-active {
+    background-color: #17c3b2;
+}
+
+.badge-inactive {
+    background-color: #fe6d73;
+}
+
+/* 권한 배지 색상 */
+.badge-master {
+    background-color: #ef476f;
+}
+
+.badge-general {
+    background-color: #ffd166;
+}
+
+.badge-senior {
+    background-color: #06d6a0;
+}
+
+.badge-warehouse {
+    background-color: #118ab2;
+}
+
+.badge-franchise {
+    background-color: #073b4c;
+}
+
+.badge-vendor {
+    background-color: #7678ed;
+}
+
+.badge-default {
+    background-color: #9ca3af;
+}
+</style>

--- a/src/features/member/master/components/MemberLoginHistory.vue
+++ b/src/features/member/master/components/MemberLoginHistory.vue
@@ -1,0 +1,157 @@
+<template>
+    <div class="card">
+        <div class="section-header">
+            <div class="title-wrapper">
+                <div class="indicator"></div>
+                <h2 class="title">로그인 내역</h2>
+            </div>
+            <p class="description">최근 로그인 활동을 확인할 수 있습니다.</p>
+        </div>
+
+        <SkeletonList v-if="isLoading" :rows="8" :columns="3" />
+        <div v-else>
+            <table class="login-table">
+                <thead>
+                <tr>
+                    <th>로그인 일시</th>
+                    <th>IP 주소</th>
+                    <th>브라우저</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr v-for="item in loginHistory" :key="item.loginAt + item.ipAddress">
+                    <td>{{ formatDateTime(item.loginAt) }}</td>
+                    <td>{{ item.ipAddress }}</td>
+                    <td>{{ item.browser }}</td>
+                </tr>
+                <tr v-if="loginHistory.length === 0">
+                    <td colspan="3" class="empty-row">로그인 내역이 없습니다.</td>
+                </tr>
+                </tbody>
+            </table>
+
+            <Pagination
+                    v-model="currentPage"
+                    :total-items="totalElements"
+                    :items-per-page="pageable.size"
+            />
+        </div>
+    </div>
+</template>
+
+<script setup>
+import {ref, watch, onMounted} from 'vue'
+import Pagination from '@/components/common/Pagination.vue'
+import {getMemberLoginHistory} from '@/features/member/api.js'
+import SkeletonList from "@/components/common/SkeletonList.vue";
+
+const props = defineProps({
+    memberId: {
+        type: [String, Number],
+        required: true,
+    },
+})
+
+const loginHistory = ref([])
+const pageable = ref({page: 0, size: 10})
+const totalElements = ref(0)
+const isLoading = ref(true)
+const currentPage = ref(1)
+
+function formatDateTime(dateTime) {
+    if (!dateTime) return '-'
+    const date = new Date(dateTime)
+    return date.toLocaleString('ko-KR', {timeZone: 'Asia/Seoul'})
+}
+
+async function fetchLoginHistory(delayMs = 0) {
+    isLoading.value = true
+    try {
+        if (delayMs > 0) {
+            await new Promise(resolve => setTimeout(resolve, delayMs))
+        }
+        const response = await getMemberLoginHistory(props.memberId, {
+            page: currentPage.value - 1,
+            size: pageable.value.size,
+        })
+        const pageData = response.data.data
+        loginHistory.value = pageData.contents
+        totalElements.value = pageData.totalElements
+    } catch (error) {
+        console.error('로그인 내역 조회 실패:', error)
+    } finally {
+        isLoading.value = false
+    }
+}
+
+onMounted(() => fetchLoginHistory(1000))
+watch(currentPage, () => fetchLoginHistory(250))
+</script>
+
+<style scoped>
+.card {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    max-width: 1500px;
+    margin: 0 auto;
+    width: 100%;
+}
+
+.section-header {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.title-wrapper {
+    display: flex;
+    align-items: center;
+}
+
+.title {
+    font-size: var(--font-page-title-large);
+    font-weight: bold;
+    color: var(--color-gray-900);
+    margin-bottom: 4px;
+    border-left: 4px solid var(--color-primary);
+    padding-left: 10px;
+}
+
+.description {
+    font-size: 1rem;
+    color: #6c757d;
+}
+
+.login-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+    margin-top: 12px;
+}
+
+.login-table th,
+.login-table td {
+    padding: 12px;
+    border-bottom: 1px solid #dee2e6;
+    text-align: left;
+}
+
+.login-table th {
+    background: #f8f9fa;
+    font-weight: 600;
+    color: #495057;
+}
+
+.login-table tr:hover {
+    background: #f1f3f5;
+}
+
+.empty-row {
+    text-align: center;
+    padding: 16px 0;
+    color: #868e96;
+}
+</style>

--- a/src/features/member/master/components/MemberTable.vue
+++ b/src/features/member/master/components/MemberTable.vue
@@ -1,0 +1,70 @@
+<template>
+    <table>
+        <thead>
+        <tr>
+            <th v-for="column in columns" :key="column.key" :style="{ textAlign: column.align || 'left' }">
+                {{ column.label }}
+            </th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr v-for="(item, index) in items" :key="item.id || index">
+            <td
+                    v-for="column in columns"
+                    :key="column.key"
+                    :style="{ textAlign: column.align || 'left' }"
+            >
+                <!-- 슬롯 렌더링 -->
+                <slot
+                        :name="`cell-${column.key}`"
+                        :item="item"
+                        :value="resolveValue(item, column, index)"
+                        :index="index"
+                >
+                    {{ resolveValue(item, column, index) }}
+                </slot>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</template>
+
+<script setup>
+
+defineProps({
+    items: {
+        type: Array,
+        required: true
+    },
+    columns: {
+        type: Array,
+        required: true
+    }
+})
+
+// 컬럼의 format 함수가 있으면 적용, 없으면 값 반환
+const resolveValue = (item, column, index) => {
+    if (typeof column.format === 'function') {
+        return column.format(item[column.key], item, index)
+    }
+    return item[column.key]
+}
+</script>
+
+<style scoped>
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+th, td {
+    padding: 12px 15px;
+    border-bottom: 1px solid var(--color-gray-200);
+    text-align: center;
+}
+thead tr {
+    background-color: var(--color-gray-100);
+}
+tbody tr:hover {
+    background-color: var(--color-gray-50);
+}
+</style>

--- a/src/features/member/master/views/MemberDetailView.vue
+++ b/src/features/member/master/views/MemberDetailView.vue
@@ -1,0 +1,71 @@
+<template>
+    <DetailLayout
+            title="회원 상세 정보"
+            description="회원의 상세 정보를 확인할 수 있습니다."
+    >
+        <template #basic>
+            <div v-if="isLoading">로딩 중...</div>
+            <div v-else-if="member">
+                <div class="detail-stack">
+                    <!-- 회원 상세 위 -->
+                    <MemberDetailBasic :member="member"/>
+                    <!-- 로그인 내역 아래 -->
+                    <MemberLoginHistory :member-id="memberId"/>
+                </div>
+            </div>
+            <div v-else>회원 정보를 불러올 수 없습니다.</div>
+        </template>
+    </DetailLayout>
+</template>
+
+<script setup>
+import {ref, onMounted} from 'vue'
+import {useRoute} from 'vue-router'
+import {getMemberDetail} from '@/features/member/api.js'
+
+import DetailLayout from '@/components/layout/DetailLayout.vue'
+import MemberDetailBasic from '@/features/member/master/components/MemberDetailBasic.vue'
+import MemberLoginHistory from '@/features/member/master/components/MemberLoginHistory.vue'
+
+const route = useRoute()
+const memberId = route.params.memberId
+
+const isLoading = ref(true)
+const member = ref(null)
+
+const fetchMemberDetail = async () => {
+    try {
+        const response = await getMemberDetail(memberId)
+        member.value = response.data.data
+    } catch (error) {
+        console.error('회원 상세 조회 실패:', error)
+    } finally {
+        isLoading.value = false
+    }
+}
+
+onMounted(fetchMemberDetail)
+</script>
+
+<style scoped>
+.action-button {
+    padding: 8px 16px;
+    background-color: var(--color-primary);
+    color: #fff;
+    border-radius: 6px;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 0.95rem;
+    transition: background-color 0.2s ease;
+}
+
+.action-button:hover {
+    background-color: var(--color-primary-dark);
+}
+
+.detail-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 24px; /* 섹션 간 여백 */
+}
+</style>

--- a/src/features/member/master/views/MemberListView.vue
+++ b/src/features/member/master/views/MemberListView.vue
@@ -6,10 +6,10 @@
         <!-- filters -->
         <template #filters>
             <form class="search-bar" @submit.prevent="handleSearch">
-                <!-- 이메일 필드에서 엔터를 누르면 handleSearch 실행 -->
-                <FilterText v-model="filters.email" label="이메일" placeholder="이메일 입력" @keydown.enter.prevent="handleSearch"/>
-                <!-- 직책 필드에서 엔터를 누르면 handleSearch 실행 -->
-                <FilterText v-model="filters.position" label="직책" placeholder="직책 입력" @keydown.enter.prevent="handleSearch"/>
+                <FilterText v-model="filters.email" label="이메일" placeholder="이메일 입력"
+                            @keydown.enter.prevent="handleSearch"/>
+                <FilterText v-model="filters.position" label="직책" placeholder="직책 입력"
+                            @keydown.enter.prevent="handleSearch"/>
                 <FilterSelect v-model="filters.authorityName" label="권한" :options="authorityOptions"/>
                 <FilterSelect v-model="filters.isDeleted" label="탈퇴 여부" :options="withdrawalOptions"/>
                 <FilterDateRange v-model="filters.joinDateRange" label="가입일 범위"/>
@@ -19,18 +19,35 @@
 
         <!-- table -->
         <template #table>
-            <SkeletonList v-if="isLoading" :rows="8" :columns="columns.length" />
-            <EmptyResult v-else-if="members.length === 0" message="등록된 회원이 없습니다." />
+            <SkeletonList v-if="isLoading" :rows="8" :columns="columns.length"/>
+            <EmptyResult v-else-if="members.length === 0" message="등록된 회원이 없습니다."/>
             <template v-else>
-                <GenericTable
-                        :columns="columns"
-                        :items="formattedMembers"
-                        @edit="handleEdit"
-                >
-                    <template #isDeleted="{ item }">
-                        <span>{{ item.isDeleted ? '탈퇴' : '정상' }}</span>
+                <GenericTable :columns="columns" :items="formattedMembers">
+                    <!-- 탈퇴 여부 컬럼 배지 -->
+                    <template #cell-isDeleted="{ value }">
+                        <span :class="['badge', value === '활동 중' ? 'badge-active' : 'badge-inactive']">
+                            {{ value }}
+                        </span>
+                    </template>
+
+                    <!-- 권한 컬럼 배지 -->
+                    <template #cell-authorityLabelKr="{ value }">
+                        <span :class="['badge', authorityBadgeClass(value)]">
+                            {{ value }}
+                        </span>
+                    </template>
+
+                    <!-- 상세 보기 버튼 -->
+                    <template #cell-detail="{ item }">
+                        <RouterLink
+                                :to="`/member/${item.memberId}`"
+                                class="detail-link"
+                        >
+                            상세 보기
+                        </RouterLink>
                     </template>
                 </GenericTable>
+
                 <Pagination
                         v-model="currentPage"
                         :total-items="totalItems"
@@ -44,98 +61,98 @@
 
 <script setup>
 import {computed, onMounted, ref, watch} from 'vue'
+import {useRouter} from 'vue-router'
 import {getMembers} from '@/features/member/api.js'
 
 import ListLayout from '@/components/layout/ListLayout.vue'
 import EmptyResult from "@/components/common/EmptyResult.vue"
 import Pagination from '@/components/common/Pagination.vue'
-import SkeletonList from "@/components/common/SkeletonList.vue"
 import GenericTable from '@/components/common/GenericTable.vue'
 import FilterText from '@/components/common/filters/FilterText.vue'
 import FilterSelect from '@/components/common/filters/FilterSelect.vue'
 import FilterButtons from '@/components/common/filters/FilterButtons.vue'
 import FilterDateRange from "@/components/common/filters/FilterDateRange.vue";
+import SkeletonList from "@/components/common/SkeletonList.vue";
+import {useAuthStore} from "@/features/auth/useAuthStore.js";
 
+// 상태
 const isLoading = ref(false)
 const currentPage = ref(1)
 const itemsPerPage = 10
 const totalItems = ref(0)
 const members = ref([])
 
+// 필터 상태
 const filters = ref({
     email: '',
     position: '',
     authorityName: '',
-    isDeleted: 'false',
-    joinDateRange: { start: '', end: '' }
+    isDeleted: null,
+    joinDateRange: {start: '', end: ''}
 })
 
+// 권한, 탈퇴 여부 옵션
 const authorityOptions = [
-    { label: '전체', value: '' },
-    { label: '마스터', value: 'MASTER' },
-    { label: '일반 관리자', value: 'GENERAL_MANAGER' },
-    { label: '책임 관리자', value: 'SENIOR_MANAGER' },
-    { label: '창고 관리자', value: 'WAREHOUSE_MANAGER' },
-    { label: '가맹점 담당자', value: 'FRANCHISE_MANAGER' },
-    { label: '거래처 담당자', value: 'VENDOR_MANAGER' },
-    { label: '시스템', value: 'SYSTEM' }
+    {label: '마스터', value: 'MASTER'},
+    {label: '일반 관리자', value: 'GENERAL_MANAGER'},
+    {label: '책임 관리자', value: 'SENIOR_MANAGER'},
+    {label: '창고 관리자', value: 'WAREHOUSE_MANAGER'},
+    {label: '가맹점 담당자', value: 'FRANCHISE_MANAGER'},
+    {label: '거래처 담당자', value: 'VENDOR_MANAGER'},
+    {label: '시스템', value: 'SYSTEM'}
 ]
 
 const withdrawalOptions = [
-    { label: '전체', value: '' },
-    { label: '정상', value: 'false' },
-    { label: '탈퇴', value: 'true' }
+    {label: '전체', value: null},
+    {label: '정상', value: 'false'},
+    {label: '탈퇴', value: 'true'}
 ]
 
+// 컬럼 정의
 const columns = [
-    { key: 'memberId', label: '아이디' },
-    { key: 'email', label: '이메일' },
-    { key: 'name', label: '이름' },
-    { key: 'authorityLabelKr', label: '권한' },
-    { key: 'phoneNumber', label: '전화번호' },
-    { key: 'birthDate', label: '생년월일' },
-    { key: 'position', label: '직책' },
-    { key: 'joinAt', label: '가입일' },
-    { key: 'isDeleted', label: '탈퇴 여부' }
+    {key: 'memberId', label: '아이디'},
+    {key: 'email', label: '이메일'},
+    {key: 'name', label: '이름'},
+    {key: 'authorityLabelKr', label: '권한'},
+    {key: 'position', label: '직책'},
+    {key: 'joinAt', label: '가입일'},
+    {key: 'isDeleted', label: '탈퇴 여부'},
+    {key: 'detail', label: '상세'}
 ]
 
-// 필터 적용을 위한 파라미터 빌드 함수
+// 파라미터 빌드
 const buildParams = () => {
-    const f = filters.value;
+    const f = filters.value
     const params = {
         page: currentPage.value - 1,
         size: itemsPerPage,
-        isDeleted: f.isDeleted === "" ? "false" : f.isDeleted,
-    };
+        isDeleted: f.isDeleted === '' ? null : f.isDeleted
+    }
+    if (f.email) params.email = f.email
+    if (f.position) params.position = f.position
+    if (f.authorityName) params.authorityName = f.authorityName
+    if (f.joinDateRange.start) params.joinDateFrom = f.joinDateRange.start
+    if (f.joinDateRange.end) params.joinDateTo = f.joinDateRange.end
 
-    // 이메일, 직책, 권한, 탈퇴 여부 필터 추가
-    if (f.email) params.email = f.email;
-    if (f.position) params.position = f.position;
-    if (f.authorityName) params.authorityName = f.authorityName;
-    if (f.isDeleted !== "") params.isDeleted = f.isDeleted;
-
-    // 날짜 범위 필터 추가
-    if (f.joinDateRange.start) params.joinDateFrom = f.joinDateRange.start;
-    if (f.joinDateRange.end) params.joinDateTo = f.joinDateRange.end;
-
-    console.log("params", params);
-    return params;
-};
+    console.log('params', params)
+    return params
+}
 
 // 회원 목록 조회
 const fetchMembers = async () => {
-    isLoading.value = true;
+    isLoading.value = true
     try {
-        const response = await getMembers(buildParams());
-        const data = response.data.data;
-        members.value = data.contents ?? [];
-        totalItems.value = data.totalElements ?? 0;
+        await new Promise(resolve => setTimeout(resolve, 500)) // UX 지연
+        const response = await getMembers(buildParams())
+        const data = response.data.data
+        members.value = data.contents ?? []
+        totalItems.value = data.totalElements ?? 0
     } catch (error) {
-        console.error("회원 목록 조회 실패:", error);
+        console.error('회원 목록 조회 실패:', error)
     } finally {
-        isLoading.value = false;
+        isLoading.value = false
     }
-};
+}
 
 // 검색 처리
 const handleSearch = () => {
@@ -149,59 +166,85 @@ const resetFilters = () => {
         email: '',
         position: '',
         authorityName: '',
-        isDeleted: '',
-        joinDateRange: { start: '', end: '' }  // 날짜 범위 초기화
+        isDeleted: null,
+        joinDateRange: {start: '', end: ''}
     }
-    handleSearch();
+    handleSearch()
 }
 
-// 수정 처리 (모달 또는 라우팅 처리)
-const handleEdit = (member) => {
-    console.log('Edit member:', member)
-    // 모달 오픈 또는 라우팅 처리
-}
-
-// 페이지 변경 시 회원 목록 재조회
+// 페이지 변경 시 조회
 watch(currentPage, fetchMembers)
 
-// 컴포넌트 마운트 시 회원 목록 조회
-onMounted(() => {
-    fetchMembers()
-})
+// 마운트 시 조회
+onMounted(fetchMembers)
 
-// 전화번호 포맷
+// 권한 배지 클래스 매핑
+const authorityBadgeClass = (label) => {
+    switch (label) {
+        case '마스터':
+            return 'badge-master'
+        case '일반 관리자':
+            return 'badge-general'
+        case '책임 관리자':
+            return 'badge-senior'
+        case '창고 관리자':
+            return 'badge-warehouse'
+        case '가맹점 담당자':
+            return 'badge-franchise'
+        case '거래처 담당자':
+            return 'badge-vendor'
+        case '시스템':
+            return 'badge-system'
+        default:
+            return 'badge-default'
+    }
+}
+
+// 포맷터
 const formatPhoneNumber = (phoneNumber) => {
     if (!phoneNumber) return ''
     return phoneNumber.replace(/^(\d{3})(\d{4})(\d{4})$/, '$1-$2-$3')
 }
 
-// 가입일 포맷
 const formatJoinDate = (joinDate) => {
-    if (!joinDate) return '';
-    const date = new Date(joinDate); // 서버에서 받은 날짜를 Date 객체로 변환
-    // 한국 시간대(KST)로 변환
+    if (!joinDate) return ''
+    const date = new Date(joinDate)
     const localDate = date.toLocaleDateString('ko-KR', {
         timeZone: 'Asia/Seoul',
         year: 'numeric',
         month: '2-digit',
         day: '2-digit'
-    });
-    // 날짜 형식을 'YYYY-MM-DD'로 수정하고, 마침표 제거
-    return localDate.replace(/\./g, '').replace(/\s/g, '-'); // '.'을 제거하고, 공백을 '-'로 변환
+    })
+    return localDate.replace(/\./g, '').replace(/\s/g, '-')
 }
 
-// 데이터 포맷 적용
-const formattedMembers = computed(() => {
-    return members.value.map(member => ({
-        ...member,
-        phoneNumber: formatPhoneNumber(member.phoneNumber),
-        joinAt: formatJoinDate(member.joinAt),
-        isDeleted: member.isDeleted ? '탈퇴' : '정상' // isDeleted 값 변환
-    }))
-})
+// 포맷된 members
+const formattedMembers = computed(() =>
+        members.value.map(member => ({
+            ...member,
+            phoneNumber: formatPhoneNumber(member.phoneNumber),
+            joinAt: formatJoinDate(member.joinAt),
+            isDeleted: member.isDeleted ? '탈퇴' : '활동 중'
+        }))
+)
+
+const router = useRouter()
+const goToMemberDetail = (memberId) => {
+    router.push(`/members/${memberId}`)
+}
+
+const authStore = useAuthStore()
+
+onMounted(() => {
+    if (authStore.authority !== 'MASTER') {
+        alert('접근 권한이 없습니다.');
+        router.replace('/'); // 혹은 원하는 다른 페이지
+    }
+});
 </script>
 
 <style scoped>
+/* 기존 스타일 유지 */
 h2 {
     text-align: center;
     font-weight: 700;
@@ -213,5 +256,57 @@ h2 {
     display: flex;
     flex-wrap: wrap;
     gap: 15px;
+}
+
+.detail-link {
+    color: var(--color-primary);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.detail-link:hover {
+    text-decoration: underline;
+}
+
+.badge {
+    padding: 4px 10px;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    color: #fff;
+    display: inline-block;
+    text-align: center;
+}
+
+.badge-active {
+    background-color: #17c3b2;
+}
+
+.badge-inactive {
+    background-color: #fe6d73;
+}
+
+/* 권한 배지 색상 */
+.badge-master {
+    background-color: #ef476f;
+}
+
+.badge-general {
+    background-color: #ffd166;
+}
+
+.badge-senior {
+    background-color: #06d6a0;
+}
+
+.badge-warehouse {
+    background-color: #118ab2;
+}
+
+.badge-franchise {
+    background-color: #073b4c;
+}
+
+.badge-vendor {
+    background-color: #7678ed;
 }
 </style>

--- a/src/features/member/router.js
+++ b/src/features/member/router.js
@@ -1,6 +1,6 @@
 /* 사용자가 보는 routes와 view를 연결 */
 import MemberListView from "@/features/member/master/views/MemberListView.vue";
-// import MemberDummyView from "@/features/member/master/views/MemberDummyView.vue";
+import MemberDetailView from "@/features/member/master/views/MemberDetailView.vue";
 
 export const memberRoutes = [
     {
@@ -10,15 +10,15 @@ export const memberRoutes = [
         meta: {requiresAuth: true, roles: ['MASTER']}
     },
     {
-        path: '/member/register',
-        name: 'MemberRegister',
-        // component: MemberRegisterView,
+        path: '/member/:memberId',
+        name: 'MemberDetailView',
+        component: MemberDetailView,
         meta: {requiresAuth: true, roles: ['MASTER']}
     },
     {
-        path: '/member/login-history',
-        name: 'LoginHistory',
-        // component: LoginHistoryView,
+        path: '/member/register',
+        name: 'MemberRegister',
+        // component: MemberRegisterView,
         meta: {requiresAuth: true, roles: ['MASTER']}
     },
     // {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,55 +3,73 @@ import {createRouter, createWebHistory} from 'vue-router'
 import LayoutDefault from '/src/components/layout/LayoutDefault.vue'
 import AuthLayout from "@/components/layout/login/AuthLayout.vue";
 
-import { categoryRoutes } from "@/features/category/router.js";
+import {categoryRoutes} from "@/features/category/router.js";
 // import { contractRoutes } from "@/features/contract/router.js";
-import { deliveryRoutes } from "@/features/delivery/router.js";
-import { disposalRoutes } from "@/features/disposal/router.js";
-import { franchiseRoutes } from "@/features/franchise/router.js";
-import { memberRoutes } from "@/features/member/router.js";
-import { orderRoutes } from "@/features/order/router.js";
-import { productRoutes } from "@/features/product/router.js";
-import { purchaseRoutes } from "@/features/purchase/router.js";
-import { requisitionRoutes } from "@/features/requisition/router.js";
-import { dashboardRoutes } from "@/features/statistics/router.js";
-import { takebackRoutes } from "@/features/takeback/router.js";
-import { vendorRoutes } from "@/features/vendor/router.js";
-import { warehouseRoutes } from "@/features/warehouse/router.js";
+import {deliveryRoutes} from "@/features/delivery/router.js";
+import {disposalRoutes} from "@/features/disposal/router.js";
+import {franchiseRoutes} from "@/features/franchise/router.js";
+import {memberRoutes} from "@/features/member/router.js";
+import {orderRoutes} from "@/features/order/router.js";
+import {productRoutes} from "@/features/product/router.js";
+import {purchaseRoutes} from "@/features/purchase/router.js";
+import {requisitionRoutes} from "@/features/requisition/router.js";
+import {dashboardRoutes} from "@/features/statistics/router.js";
+import {takebackRoutes} from "@/features/takeback/router.js";
+import {vendorRoutes} from "@/features/vendor/router.js";
+import {warehouseRoutes} from "@/features/warehouse/router.js";
 import {AuthRoutes} from "@/features/auth/router.js";
+import {useAuthStore} from "@/features/auth/useAuthStore.js";
 
 const router = createRouter({
-  history: createWebHistory(),
-  routes: [
-    {
-      path: '/',
-      component: LayoutDefault,
-      children: [
-          {
-              path: '',
-              redirect: '/dashboard/prediction' // 기본 페이지
-          },
-          ...categoryRoutes,
-          // ...contractRoutes,
-          ...deliveryRoutes,
-          ...disposalRoutes,
-          ...franchiseRoutes,
-          ...memberRoutes,
-          ...orderRoutes,
-          ...productRoutes,
-          ...purchaseRoutes,
-          ...requisitionRoutes,
-          ...dashboardRoutes,
-          ...takebackRoutes,
-          ...vendorRoutes,
-          ...warehouseRoutes
-      ]
-    },
-      {
-          path: '/login',
-          component: AuthLayout,
-          children: AuthRoutes
-      },
-  ],
+    history: createWebHistory(),
+    routes: [
+        {
+            path: '/',
+            component: LayoutDefault,
+            children: [
+                {
+                    path: '',
+                    redirect: '/dashboard/prediction' // 기본 페이지
+                },
+                ...categoryRoutes,
+                // ...contractRoutes,
+                ...deliveryRoutes,
+                ...disposalRoutes,
+                ...franchiseRoutes,
+                ...memberRoutes,
+                ...orderRoutes,
+                ...productRoutes,
+                ...purchaseRoutes,
+                ...requisitionRoutes,
+                ...dashboardRoutes,
+                ...takebackRoutes,
+                ...vendorRoutes,
+                ...warehouseRoutes
+            ]
+        },
+        {
+            path: '/login',
+            component: AuthLayout,
+            children: AuthRoutes
+        },
+    ],
 })
+
+router.beforeEach((to, from, next) => {
+    const authStore = useAuthStore();
+
+    if (to.meta.requiresAuth && !authStore.accessToken) {
+        return next('/login');
+    }
+
+    if (to.meta.roles && Array.isArray(to.meta.roles)) {
+        if (!to.meta.roles.includes(authStore.authority)) {
+            alert('접근 권한이 없습니다.');
+            return next('/');
+        }
+    }
+
+    return next();
+});
 
 export default router

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,0 +1,13 @@
+export function parseJwt(token) {
+    if (!token) return null;
+    const base64Url = token.split('.')[1];
+    if (!base64Url) return null;
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const jsonPayload = decodeURIComponent(
+            atob(base64).split('').map(c =>
+                    '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+            ).join('')
+    );
+
+    return JSON.parse(jsonPayload);
+}


### PR DESCRIPTION
Closes #27 

## 🔥 작업 내용  
- 회원 목록 페이지에서 상세 보기 컬럼 추가
- 상세 보기를 클릭하면 해당 회원의 상세 페이지로 이동하도록 구현
- 회원 정보 영역 구현
- 로그인 내역 구현
- 권한에 따른 색상 적용
- 탈퇴 여부 값에 색상 적용 

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인

## ✨ 관련 이슈
- #27 
