### PR TITLE
feat: 회원 마이페이지 기능 구현

### DIFF
--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -106,7 +106,7 @@ const toggleMypageDropdown = () => {
 const goToMypage = () => {
     emits('selectMenu', '마이페이지')
     showMypageDropdown.value = false
-    router.push('/mypage/info')
+    router.push('/mypage/profile')
 }
 
 const logout = async () => {

--- a/src/constants/sidebarMap.js
+++ b/src/constants/sidebarMap.js
@@ -153,8 +153,8 @@ export const sidebarMap = {
             title: "마이페이지",
             icon: 'fas fa-circle-user',
             items: [
-                { name: "회원 정보 조회", route: "/mypage/info", icon: "fas fa-id-card", roles: ["MASTER", "GENERAL_MANAGER", "SENIOR_MANAGER", "WAREHOUSE_MANAGER", "FRANCHISE_MANAGER", "VENDOR_MANAGER", "SYSTEM"] },
-                { name: "비밀번호 변경", route: "/mypage/password", icon: "fas fa-key", roles: ["MASTER", "GENERAL_MANAGER", "SENIOR_MANAGER", "WAREHOUSE_MANAGER", "FRANCHISE_MANAGER", "VENDOR_MANAGER", "SYSTEM"] }
+                { name: "회원 정보 조회", route: "/mypage/profile", icon: "fas fa-id-card", roles: ["MASTER", "GENERAL_MANAGER", "SENIOR_MANAGER", "WAREHOUSE_MANAGER", "FRANCHISE_MANAGER", "VENDOR_MANAGER", "SYSTEM"] },
+                { name: "비밀번호 변경", route: "/mypage/change-password", icon: "fas fa-key", roles: ["MASTER", "GENERAL_MANAGER", "SENIOR_MANAGER", "WAREHOUSE_MANAGER", "FRANCHISE_MANAGER", "VENDOR_MANAGER", "SYSTEM"] }
             ]
         }
     ]

--- a/src/features/member/api.js
+++ b/src/features/member/api.js
@@ -49,3 +49,19 @@ export const vendorMemberRegister = (formData) => {
         headers: {'Content-Type': 'multipart/form-data'}
     });
 }
+
+export const getMyProfile = () => {
+    return api.get('/members/me');
+};
+
+export const updateMyInfo = (formData) => {
+    return api.put('/members/me', JSON.stringify(formData), {
+        headers: {'Content-Type': 'application/json'}
+    });
+}
+
+export const changePassword = (formData) => {
+    return api.put("/members/password", JSON.stringify(formData), {
+        headers: {'Content-Type': 'application/json'}
+    });
+}

--- a/src/features/member/master/components/MemberDetailBasic.vue
+++ b/src/features/member/master/components/MemberDetailBasic.vue
@@ -47,14 +47,14 @@
 </template>
 
 <script setup>
-import {ref} from 'vue'
-import {useRouter} from 'vue-router'
+import { ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import InputField from '@/components/common/fields/InputField.vue'
 import SelectField from '@/components/common/fields/SelectField.vue'
-import {updateMember, deleteMember} from '@/features/member/api.js'
+import { updateMember, deleteMember } from '@/features/member/api.js'
 
 const props = defineProps({
-    member: {type: Object, required: true}
+    member: { type: Object, required: true }
 })
 
 const emit = defineEmits(['refresh'])
@@ -68,18 +68,16 @@ const form = ref({
     position: ''
 })
 
-// 권한 옵션 (시스템 포함)
 const authorityOptions = [
-    {label: '마스터', value: 'MASTER'},
-    {label: '일반 관리자', value: 'GENERAL_MANAGER'},
-    {label: '책임 관리자', value: 'SENIOR_MANAGER'},
-    {label: '창고 관리자', value: 'WAREHOUSE_MANAGER'},
-    {label: '가맹점 담당자', value: 'FRANCHISE_MANAGER'},
-    {label: '거래처 담당자', value: 'VENDOR_MANAGER'},
-    {label: '시스템', value: 'SYSTEM'}
+    { label: '마스터', value: 'MASTER' },
+    { label: '일반 관리자', value: 'GENERAL_MANAGER' },
+    { label: '책임 관리자', value: 'SENIOR_MANAGER' },
+    { label: '창고 관리자', value: 'WAREHOUSE_MANAGER' },
+    { label: '가맹점 담당자', value: 'FRANCHISE_MANAGER' },
+    { label: '거래처 담당자', value: 'VENDOR_MANAGER' },
+    { label: '시스템', value: 'SYSTEM' }
 ]
 
-// Label → Enum 매핑
 const labelToValueMap = {
     '마스터': 'MASTER',
     '일반 관리자': 'GENERAL_MANAGER',
@@ -93,7 +91,7 @@ const labelToValueMap = {
 function formatDateTime(dateTime) {
     if (!dateTime) return '-'
     const date = new Date(dateTime)
-    return date.toLocaleString('ko-KR', {timeZone: 'Asia/Seoul'})
+    return date.toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' })
 }
 
 function formatPhoneNumber(phoneNumber) {
@@ -110,29 +108,21 @@ function formatPhoneNumber(phoneNumber) {
 
 function authorityBadgeClass(label) {
     switch (label) {
-        case '마스터':
-            return 'badge-master'
-        case '일반 관리자':
-            return 'badge-general'
-        case '책임 관리자':
-            return 'badge-senior'
-        case '창고 관리자':
-            return 'badge-warehouse'
-        case '가맹점 담당자':
-            return 'badge-franchise'
-        case '거래처 담당자':
-            return 'badge-vendor'
-        case '시스템':
-            return 'badge-system'
-        default:
-            return 'badge-default'
+        case '마스터': return 'badge-master'
+        case '일반 관리자': return 'badge-general'
+        case '책임 관리자': return 'badge-senior'
+        case '창고 관리자': return 'badge-warehouse'
+        case '가맹점 담당자': return 'badge-franchise'
+        case '거래처 담당자': return 'badge-vendor'
+        case '시스템': return 'badge-system'
+        default: return 'badge-default'
     }
 }
 
 const rows = [
-    {label: '회원 ID', value: props.member.memberId},
-    {label: '이메일', value: props.member.email},
-    {label: '이름', value: props.member.name, editable: true, key: 'name'},
+    { label: '회원 ID', value: props.member.memberId },
+    { label: '이메일', value: props.member.email },
+    { label: '이름', value: props.member.name, editable: true, key: 'name' },
     {
         label: '권한',
         value: props.member.authorityLabelKr,
@@ -141,11 +131,11 @@ const rows = [
         key: 'authorityName',
         badgeClass: authorityBadgeClass(props.member.authorityLabelKr)
     },
-    {label: '전화번호', value: formatPhoneNumber(props.member.phoneNumber), editable: true, key: 'phoneNumber'},
-    {label: '생년월일', value: props.member.birthDate},
-    {label: '직책', value: props.member.position, editable: true, key: 'position'},
-    {label: '가입일', value: formatDateTime(props.member.joinAt)},
-    {label: '수정일', value: formatDateTime(props.member.modifiedAt)},
+    { label: '전화번호', value: formatPhoneNumber(props.member.phoneNumber), editable: true, key: 'phoneNumber' },
+    { label: '생년월일', value: props.member.birthDate },
+    { label: '직책', value: props.member.position, editable: true, key: 'position' },
+    { label: '가입일', value: formatDateTime(props.member.joinAt) },
+    { label: '수정일', value: formatDateTime(props.member.modifiedAt) },
     {
         label: '탈퇴 여부',
         value: props.member.isDeleted ? '탈퇴' : '활동 중',
@@ -159,7 +149,7 @@ const enterEditMode = () => {
     form.value = {
         name: props.member.name ?? '',
         authorityName: labelToValueMap[props.member.authorityLabelKr] ?? 'MASTER',
-        phoneNumber: props.member.phoneNumber ?? '',
+        phoneNumber: formatPhoneNumber(props.member.phoneNumber ?? ''),
         position: props.member.position ?? ''
     }
 }
@@ -173,11 +163,14 @@ const handleSave = async () => {
         alert('권한을 선택해주세요.')
         return
     }
-    if (!confirm('회원 정보를 수정하시겠습니까?')) {
-        return
-    }
+    if (!confirm('회원 정보를 수정하시겠습니까?')) return
+
     try {
-        await updateMember(props.member.memberId, form.value)
+        const payload = {
+            ...form.value,
+            phoneNumber: form.value.phoneNumber.replace(/\D/g, '')
+        }
+        await updateMember(props.member.memberId, payload)
         emit('refresh')
         isEditMode.value = false
     } catch (error) {
@@ -187,18 +180,29 @@ const handleSave = async () => {
 }
 
 const handleDelete = async () => {
-    if (!confirm('정말로 이 회원을 탈퇴 처리하시겠습니까?')) {
-        return
-    }
+    if (!confirm('정말로 이 회원을 탈퇴 처리하시겠습니까?')) return
+
     try {
         await deleteMember(props.member.memberId)
         alert('회원이 탈퇴 처리되었습니다.')
-        router.push('/member/list')
+        await router.push('/member/list')
     } catch (error) {
         console.error('회원 탈퇴 실패:', error)
         alert('회원 탈퇴 처리에 실패했습니다.')
     }
 }
+
+watch(() => form.value.phoneNumber, (val) => {
+    if (!val) return
+    const digits = val.replace(/\D/g, '')
+    if (digits.length <= 3) {
+        form.value.phoneNumber = digits
+    } else if (digits.length <= 7) {
+        form.value.phoneNumber = digits.replace(/(\d{3})(\d{1,4})/, '$1-$2')
+    } else {
+        form.value.phoneNumber = digits.replace(/(\d{3})(\d{4})(\d{1,4})/, '$1-$2-$3')
+    }
+})
 </script>
 
 <style scoped>

--- a/src/features/member/mypage/views/ChangePasswordView.vue
+++ b/src/features/member/mypage/views/ChangePasswordView.vue
@@ -1,0 +1,187 @@
+<template>
+    <DetailLayout
+            title="비밀번호 변경"
+            description="회원 비밀번호를 변경할 수 있습니다."
+    >
+        <template #basic>
+            <transition name="fade-slide" appear>
+                <div class="card">
+                    <form @submit.prevent="handleSubmit" class="form-stack">
+                        <!-- 현재 비밀번호 -->
+                        <div class="form-group">
+                            <label>현재 비밀번호</label>
+                            <input
+                                    v-model="form.currentPassword"
+                                    type="password"
+                                    placeholder="현재 비밀번호 입력"
+                            />
+                            <p v-if="currentError" class="error-text">{{ currentError }}</p>
+                        </div>
+
+                        <!-- 새 비밀번호 -->
+                        <div class="form-group">
+                            <label>새 비밀번호</label>
+                            <input
+                                    v-model="form.newPassword"
+                                    type="password"
+                                    placeholder="새 비밀번호 입력 (8자리 이상)"
+                            />
+                            <p v-if="passwordError" class="error-text">{{ passwordError }}</p>
+                        </div>
+
+                        <!-- 새 비밀번호 확인 -->
+                        <div class="form-group">
+                            <label>새 비밀번호 확인</label>
+                            <input
+                                    v-model="form.confirmPassword"
+                                    type="password"
+                                    placeholder="새 비밀번호 재입력"
+                            />
+                            <p v-if="confirmError" class="error-text">{{ confirmError }}</p>
+                        </div>
+
+                        <button type="submit" class="submit-button">
+                            비밀번호 변경
+                        </button>
+                    </form>
+                </div>
+            </transition>
+        </template>
+    </DetailLayout>
+</template>
+
+<script setup>
+import { reactive, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import DetailLayout from '@/components/layout/DetailLayout.vue'
+import { changePassword } from '@/features/member/api.js'
+
+const router = useRouter()
+
+const form = reactive({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: '',
+})
+
+const currentError = ref('')
+const passwordError = ref('')
+const confirmError = ref('')
+
+const validatePassword = (password) => password.length >= 8
+
+const handleSubmit = async () => {
+    currentError.value = ''
+    passwordError.value = ''
+    confirmError.value = ''
+
+    if (!form.currentPassword) {
+        currentError.value = '현재 비밀번호를 입력하세요.'
+        return
+    }
+
+    if (!validatePassword(form.newPassword)) {
+        passwordError.value = '비밀번호는 8자리 이상이어야 합니다.'
+        return
+    }
+
+    if (form.newPassword !== form.confirmPassword) {
+        confirmError.value = '새 비밀번호와 확인이 일치하지 않습니다.'
+        return
+    }
+
+    try {
+        await changePassword(form)
+        alert('비밀번호가 변경되었습니다. 다시 로그인해주세요.')
+        await router.push('/login')
+    } catch (error) {
+        const message = error.response?.data?.message || '비밀번호 변경에 실패했습니다.'
+        alert(message)
+    }
+}
+</script>
+
+<style scoped>
+/* 애니메이션 정의 */
+.fade-slide-enter-active {
+    animation: fadeSlideIn 0.4s ease-out both;
+}
+
+@keyframes fadeSlideIn {
+    0% {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.card {
+    background: #fff;
+    border-radius: 12px;
+    padding: 40px 24px; /* 상하 여백을 키움 */
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    min-width: 500px;
+    max-width: 600px;
+    margin: 100px auto;
+
+    min-height: 280px; /* 카드 기본 세로 길이 */
+}
+
+.form-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+}
+
+label {
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: #333;
+    margin-bottom: 4px;
+}
+
+input {
+    padding: 10px 12px;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    font-size: 0.95rem;
+    font-family: 'Noto Sans KR', sans-serif;
+    margin-bottom: 4px;
+}
+
+input:focus {
+    border-color: var(--color-primary);
+    outline: none;
+}
+
+.submit-button {
+    padding: 10px;
+    background-color: var(--color-primary);
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-weight: 600;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    margin-top: 10px;
+}
+
+.submit-button:hover {
+    background-color: var(--color-primary-dark, #2c91bc);
+}
+
+.error-text {
+    color: red;
+    font-size: 0.8rem;
+    margin: 0;
+}
+</style>

--- a/src/features/member/mypage/views/MyProfileView.vue
+++ b/src/features/member/mypage/views/MyProfileView.vue
@@ -1,0 +1,314 @@
+<template>
+    <DetailLayout
+            title="내 프로필"
+            description="회원님의 프로필 정보를 확인하고 수정할 수 있습니다."
+    >
+        <template #basic>
+            <div v-if="isLoading">로딩 중...</div>
+            <div v-else-if="member">
+                <div class="detail-stack">
+                    <div class="card">
+                        <div class="section-header">
+                            <div class="title-wrapper">
+                                <div class="indicator"></div>
+                                <h2 class="title">회원 정보</h2>
+                            </div>
+
+                            <div v-if="!isEditMode" class="button-group">
+                                <button class="action-button" @click="enterEditMode">수정</button>
+                            </div>
+
+                            <div v-else class="edit-buttons">
+                                <button class="action-button" @click="handleSave">저장</button>
+                                <button class="cancel-button" @click="cancelEdit">취소</button>
+                            </div>
+                        </div>
+
+                        <p class="description">회원 상세 내용을 확인할 수 있습니다.</p>
+
+                        <div class="info-grid">
+                            <div class="info-item" v-for="item in rows" :key="item.label">
+                                <div class="label">{{ item.label }}</div>
+                                <div class="value">
+                                    <template v-if="item.editable && isEditMode">
+                                        <InputField
+                                                v-model="form[item.key]"
+                                                :placeholder="item.label + '을(를) 입력하세요'"
+                                        />
+                                    </template>
+                                    <template v-else-if="item.type === 'badge'">
+                                        <span :class="['badge', item.badgeClass]">{{ item.value }}</span>
+                                    </template>
+                                    <template v-else>
+                                        {{ item.value || '-' }}
+                                    </template>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div v-else>회원 정보를 불러올 수 없습니다.</div>
+        </template>
+    </DetailLayout>
+</template>
+
+<script setup>
+import { ref, onMounted, watch } from 'vue'
+import InputField from '@/components/common/fields/InputField.vue'
+import DetailLayout from '@/components/layout/DetailLayout.vue'
+import { getMyProfile, updateMyInfo } from '@/features/member/api.js'
+
+const isLoading = ref(true)
+const isEditMode = ref(false)
+const member = ref(null)
+const form = ref({ phoneNumber: '' })
+const rows = ref([])
+
+function formatPhoneNumber(phoneNumber) {
+    if (!phoneNumber) return '-'
+    const cleaned = phoneNumber.replace(/\D/g, '')
+    if (cleaned.length === 10) {
+        return cleaned.replace(/(\d{3})(\d{3})(\d{4})/, '$1-$2-$3')
+    }
+    if (cleaned.length === 11) {
+        return cleaned.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3')
+    }
+    return phoneNumber
+}
+
+function authorityBadgeClass(label) {
+    switch (label) {
+        case '마스터': return 'badge-master'
+        case '일반 관리자': return 'badge-general'
+        case '책임 관리자': return 'badge-senior'
+        case '창고 관리자': return 'badge-warehouse'
+        case '가맹점 담당자': return 'badge-franchise'
+        case '거래처 담당자': return 'badge-vendor'
+        case '시스템': return 'badge-system'
+        default: return 'badge-default'
+    }
+}
+
+const fetchProfile = async () => {
+    isLoading.value = true
+    try {
+        const res = await getMyProfile()
+        const data = res.data.data
+        member.value = data
+
+        rows.value = [
+            { label: '이메일', value: data.email },
+            { label: '이름', value: data.name },
+            { label: '권한', value: data.authorityLabelKr, type: 'badge', badgeClass: authorityBadgeClass(data.authorityLabelKr) },
+            {
+                label: '전화번호',
+                value: formatPhoneNumber(data.phoneNumber),
+                editable: true,
+                key: 'phoneNumber'
+            },
+            { label: '생년월일', value: data.birthDate },
+            { label: '직책', value: data.position }
+        ]
+
+        form.value.phoneNumber = formatPhoneNumber(data.phoneNumber)
+    } catch (err) {
+        console.error('프로필 조회 실패:', err)
+    } finally {
+        isLoading.value = false
+    }
+}
+
+const enterEditMode = () => {
+    isEditMode.value = true
+}
+
+const cancelEdit = () => {
+    isEditMode.value = false
+    form.value.phoneNumber = formatPhoneNumber(member.value.phoneNumber)
+}
+
+const handleSave = async () => {
+    if (!form.value.phoneNumber) {
+        alert('전화번호를 입력해주세요.')
+        return
+    }
+
+    const payload = {
+        phoneNumber: form.value.phoneNumber.replace(/\D/g, '')
+    }
+
+    try {
+        await updateMyInfo(payload)
+        alert('전화번호가 수정되었습니다.')
+        isEditMode.value = false
+        await fetchProfile()
+    } catch (err) {
+        console.error('전화번호 수정 실패:', err)
+        alert('전화번호 수정에 실패했습니다.')
+    }
+}
+
+watch(() => form.value.phoneNumber, (val) => {
+    if (!val) return
+    const digits = val.replace(/\D/g, '')
+    if (digits.length <= 3) {
+        form.value.phoneNumber = digits
+    } else if (digits.length <= 7) {
+        form.value.phoneNumber = digits.replace(/(\d{3})(\d{1,4})/, '$1-$2')
+    } else {
+        form.value.phoneNumber = digits.replace(/(\d{3})(\d{4})(\d{1,4})/, '$1-$2-$3')
+    }
+})
+
+onMounted(fetchProfile)
+</script>
+
+<style scoped>
+.card {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    max-width: 1500px;
+    margin: 0 auto;
+    width: 100%;
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.title-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.title {
+    font-size: var(--font-page-title-large);
+    font-weight: bold;
+    color: var(--color-gray-900);
+    margin-bottom: 4px;
+    border-left: 4px solid var(--color-primary);
+    padding-left: 10px;
+}
+
+.description {
+    font-size: 0.95rem;
+    color: #6c757d;
+    margin-bottom: 16px;
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+@media (max-width: 768px) {
+    .info-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.info-item {
+    background: #f9fafb;
+    border-radius: 8px;
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+}
+
+.label {
+    font-size: 0.85rem;
+    color: #6c757d;
+    margin-bottom: 4px;
+}
+
+.value {
+    font-weight: 600;
+    color: #212529;
+    word-break: break-word;
+}
+
+.button-group,
+.edit-buttons {
+    display: flex;
+    gap: 7px;
+}
+
+.action-button {
+    padding: 6px 14px;
+    background-color: var(--color-primary, #2F80ED);
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    font-weight: 500;
+    font-size: 0.9rem;
+    transition: background-color 0.2s ease;
+    cursor: pointer;
+}
+
+.cancel-button {
+    padding: 6px 14px;
+    background-color: #e0e0e0;
+    color: #333;
+    border: none;
+    border-radius: 6px;
+    font-weight: 500;
+    font-size: 0.9rem;
+    transition: background-color 0.2s ease;
+    cursor: pointer;
+}
+
+.detail-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.badge {
+    padding: 4px 10px;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    color: #fff;
+    display: inline-block;
+    text-align: center;
+}
+
+.badge-master {
+    background-color: #ef476f;
+}
+
+.badge-general {
+    background-color: #ffd166;
+}
+
+.badge-senior {
+    background-color: #06d6a0;
+}
+
+.badge-warehouse {
+    background-color: #118ab2;
+}
+
+.badge-franchise {
+    background-color: #073b4c;
+}
+
+.badge-vendor {
+    background-color: #7678ed;
+}
+
+.badge-system {
+    background-color: #6c5ce7;
+}
+
+.badge-default {
+    background-color: #9ca3af;
+}
+</style>

--- a/src/features/member/router.js
+++ b/src/features/member/router.js
@@ -1,8 +1,9 @@
 /* 사용자가 보는 routes와 view를 연결 */
 import MemberListView from "@/features/member/master/views/MemberListView.vue";
 import MemberDetailView from "@/features/member/master/views/MemberDetailView.vue";
-import MemberDummyView from "@/features/member/master/views/MemberDummyView.vue";
 import MemberRegisterView from "@/features/member/master/views/MemberRegisterView.vue";
+import ChangePasswordView from "@/features/member/mypage/views/ChangePasswordView.vue";
+import MyProfileView from "@/features/member/mypage/views/MyProfileView.vue";
 
 export const memberRoutes = [
     {
@@ -24,9 +25,9 @@ export const memberRoutes = [
         meta: {requiresAuth: true, roles: ['MASTER']}
     },
     {
-        path: '/mypage/info',
-        name: 'MemberDummy5View',
-        component: MemberDummyView,
+        path: '/mypage/profile',
+        name: 'MyProfile',
+        component: MyProfileView,
         requiresAuth: true,
         roles: [
             'MASTER', 'GENERAL_MANAGER', 'SENIOR_MANAGER',
@@ -34,9 +35,9 @@ export const memberRoutes = [
         ]
     },
     {
-        path: '/mypage/password',
+        path: '/mypage/change-password',
         name: 'ChangePassword',
-        // component: ChangePasswordView,
+        component: ChangePasswordView,
         meta: {
             requiresAuth: true,
             roles: [


### PR DESCRIPTION
Closes #42 

## 🔥 작업 내용  
- 회원 정보 조회 페이지 구현
  - 기본 레이아웃 구성
  - 전화번호 하이픈 실시간 입력 처리 적용
  - 전화번호 저장 시 숫자만 전송
  - 권한별 색상 뱃지 표시
  - 회원 ID는 화면에서 제거
- 비밀번호 변경 페이지 구현
- 백엔드 API 연동
  - `/members/me` API 연동 완료
  - 프로필 정보 가져오기 및 수정 적용
- router 설정 완료
  - `/my/profile` 및 `/my/password` 등 경로 등록

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인

## ✨ 관련 이슈
- #42 
