### PR TITLE
fix: Axios 인터셉터 무한 새로고침 방지 및 예외 처리 개선 

### DIFF
--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -38,13 +38,11 @@ api.interceptors.response.use(
             const originalRequest = error.config;
 
             if (originalRequest.url.includes('/auth/refresh')) {
-                // 리프레시 토큰도 만료된 경우
                 authStore.clearAuth();
-                router.push('/login').then(() => {
-                    window.location.reload(); // 또는 router.push('/login')
-                });
+                await router.push('/login');
                 return Promise.reject(error);
             }
+
 
             if (error.response?.status === 401 && !originalRequest._retry) {
                 originalRequest._retry = true;
@@ -54,9 +52,7 @@ api.interceptors.response.use(
                     return api(originalRequest);
                 } catch (refreshError) {
                     authStore.clearAuth();
-                    router.push('/login').then(() => {
-                        window.location.reload();
-                    });
+                    await router.push('/login');
                     return Promise.reject(refreshError);
                 }
             }


### PR DESCRIPTION
Closes #64 

## 🔥 작업 내용  
- Axios 인터셉터에서 토큰 만료 시 `window.location.reload()`로 인해 발생하던 무한 새로고침 현상을 방지하고, 리프레시 토큰 만료 시에는 새로고침 없이 로그인 페이지로만 이동하도록 수정
- Axios 응답 인터셉터에서 `window.location.reload()` 제거
- 토큰 만료 시 `router.push('/login')` 처리
- 401 에러 재시도는 1회만 동작하도록 _retry 플래그 활용


## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인

## ✨ 관련 이슈
- #64 
