### PR TITLE
refactor: axios baseURL 환경변수 제거 및 코드 상에 명시

### DIFF
--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -2,7 +2,7 @@ import axios from "axios";
 import router from "@/router";
 
 const api = axios.create({
-    baseURL: import.meta.env.VITE_API_BASE_URL,
+    baseURL: "https://api.chainware.site/api/v1",
     withCredentials: true,
 });
 


### PR DESCRIPTION
Closes #77 

## 🔥 작업 내용  
- 기존에 `.env`에서 관리하던 `VITE_API_BASE_URL` 환경변수를 제거하고 `axios.js` 파일에 직접 명시하도록 수정
- 환경변수 `VITE_API_BASE_URL` 관련 설정 제거  
- `.env` 및 `import.meta.env` 참조 코드 삭제  
- `axios.js`에 API 도메인 URL 직접 명시  

##  체크 리스트  
- [x] 기능 정상 동작 확인

## ✨ 관련 이슈
- #77 
