### PR TITLE
refactor: 회원 수정 및 탈퇴 시 confirm 사용을 alertModal로 변경

### DIFF
--- a/src/features/member/master/components/MemberDetailBasic.vue
+++ b/src/features/member/master/components/MemberDetailBasic.vue
@@ -170,13 +170,13 @@ const handleSave = async () => {
         await alertModal.value.open('권한을 선택해주세요.')
         return
     }
-    if (!confirm('회원 정보를 수정하시겠습니까?')) return
 
     try {
         const payload = {
             ...form.value,
             phoneNumber: form.value.phoneNumber.replace(/\D/g, '')
         }
+        await alertModal.value.open('회원 정보를 수정하시겠습니까?')
         await updateMember(props.member.memberId, payload)
         emit('refresh')
         isEditMode.value = false
@@ -187,9 +187,8 @@ const handleSave = async () => {
 }
 
 const handleDelete = async () => {
-    if (!confirm('정말로 이 회원을 탈퇴 처리하시겠습니까?')) return
-
     try {
+        await alertModal.value.open('정말로 이 회원을 탈퇴 처리하시겠습니까?')
         await deleteMember(props.member.memberId)
         await alertModal.value.open('회원이 탈퇴 처리되었습니다.')
         await router.push('/member/list')


### PR DESCRIPTION
Closes #100 

## 🔥 작업 내용  
- `handleSubmit` 내 `confirm('회원 정보를 수정하시겠습니까?')` 호출 제거  
- `handleDelete` 내 `confirm('정말로 이 회원을 탈퇴 처리하시겠습니까?')` 호출 제거  
- `await alertModal.value.open(...)` 형태로 변경 후 정상 동작 확인  

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인

## ✨ 관련 이슈
- #100 
